### PR TITLE
Adding infiniteLoop prop

### DIFF
--- a/BaseEmitter.js
+++ b/BaseEmitter.js
@@ -36,7 +36,8 @@ export type BaseEmitterType = {
   /** Function to calculate a new bunch of particles */
   onCalculate: (position: VectorType, count: number) => ParticleConfig[],
   /** Function used to animate particles */
-  onAnimate: (Animated.Value, Animated.Value) => void
+  onAnimate: (Animated.Value, Animated.Value) => void,
+  infiniteLoop?: boolean
 };
 
 type BaseEmitterState = {
@@ -71,7 +72,8 @@ class BaseEmitter extends React.Component<BaseEmitterType, BaseEmitterState> {
     autoStart: true,
     width: windowDimensions.width,
     height: windowDimensions.height,
-    fromPosition: Vector(0, 0)
+    fromPosition: Vector(0, 0),
+    infinite: false
   };
 
   constructor(props: BaseEmitterType) {
@@ -170,7 +172,7 @@ class BaseEmitter extends React.Component<BaseEmitterType, BaseEmitterState> {
 
     if (!this.isEmitting) return;
 
-    if (this.particlesCounter >= numberOfParticles) {
+    if (this.particlesCounter >= numberOfParticles && !this.props.infiniteLoop) {
       // Stop emitting new particles
       return this.stopEmitting();
     }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Basically, the `children` of emmiter is clonned and transformed into a particle.
 - **`autoStart`** _(boolean)_ - Start emitting particles right after initialization
 - **`style`** _(Object)_ -  Style of the container view
 - **`children`** _(ReactElement)_ - Particle content
+- **`infiniteLoop`** _(boolean)_ - Emit particles infinitely
 
 ## Contribution
 **Issues** are welcome. Please add a screenshot of bug and code snippet. Quickest way to solve issue is to reproduce it on one of the examples.


### PR DESCRIPTION
I found myself also needing infinite particles, like in issue #6.
Added a prop `infiniteLoop` which prevents `stopEmitting` from being fired if it is true. 